### PR TITLE
Remove useless export

### DIFF
--- a/src/js/data.js
+++ b/src/js/data.js
@@ -36,5 +36,3 @@ export const generators = [
   { url: "https://source.unsplash.com/800x800/?chicken", weight: 1 },
   { url: "https://source.unsplash.com/800x800/?angry", weight: 3 },
 ];
-
-export default claims;


### PR DESCRIPTION
Removes the `export default claims` in `data.js` as it is never used.

Also, default exports shouldn't be used at all, because they allow to import under a different name, which makes the code less readable. Named exports are the way.

I just want to be a contributor on this thing lol